### PR TITLE
[INFRA-113] Repair preStop hook

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -1,5 +1,5 @@
 name: pgbouncer
-version: 0.2.3
+version: 0.2.4
 description: Chart for PGBouncer
 keywords:
 - postgresql

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -51,7 +51,8 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["kill", "-INT", "1", "&&", "sleep", "120"]   
+              # Signal pgbouncer to drain connections and give it two minutes to do so.
+              command: ["/bin/sh", "-c", "kill -INT 1 && sleep 120"]
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
* Discovered via cluster events in Sandbox, forest for the trees much.:
```
Exec lifecycle hook ([kill -INT 1 && sleep 120]) for Container "pgbouncer" in Pod "pgbouncer-578b96c957-s6s2x_default(5913ea87-0ae3-11ea-9fee-0e97ed943e42)" failed - error: command 'kill -INT 1 && sleep 120' exited with 1: kill: failed to parse argument: '&&'
, message: "kill: failed to parse argument: '&&'\n"
```